### PR TITLE
Refactor code highlighting and CSS inlining in wechat-styler.ts

### DIFF
--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -37,6 +37,7 @@ const options = {
 	logLevel: "info",
 	sourcemap: prod ? false : 'inline',
 	treeShaking: true,
+	minify: prod, // 生产模式启用代码压缩
 	outfile: 'main.js',
 };
 


### PR DESCRIPTION
- Changed applyCodeHighlighting to be asynchronous and dynamically import highlight.js to reduce bundle size.
- Registered common languages for syntax highlighting on demand.
- Updated code highlighting logic to use the new import method.
- Dynamically imported juice for CSS inlining instead of static import.