### PR TITLE
fix: use juice to inline CSS for better copy/paste compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,3 @@ Thumbs.db
 
 # TypeScript cache
 *.tsbuildinfo
-
-#Others
-custom/

--- a/custom/colorful-style.css
+++ b/custom/colorful-style.css
@@ -1,0 +1,218 @@
+/* post 主题 - 自定义样式 */
+
+.mp-content-section {
+  font-size: 16px;
+  color: #333;
+  line-height: 1.8;
+  letter-spacing: 0.02em;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'PingFang SC', 'Hiragino Sans GB', 'Microsoft YaHei', sans-serif;
+  background-image:
+    linear-gradient(rgba(200, 200, 220, 0.15) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(200, 200, 220, 0.15) 1px, transparent 1px);
+  background-size: 24px 24px;
+}
+
+/* ========== 标题 ========== */
+
+/* 一级标题：红色居中 */
+.mp-content-section h1 {
+  margin: 36px 0 18px;
+  font-size: 1.8em;
+  font-weight: bold;
+  color: #e03030;
+  text-align: center;
+}
+
+/* 二级标题：左侧绿色竖线 + 绿色文字 */
+.mp-content-section h2 {
+  margin: 30px 0 15px;
+  font-size: 1.4em;
+  font-weight: bold;
+  color: #4C8027;
+  padding-left: 12px;
+  border-left: 4px solid #4B8026;
+}
+
+/* 三级标题：蓝紫色文字 + 浅蓝紫背景 */
+.mp-content-section h3 {
+  margin: 24px 0 12px;
+  font-size: 1.2em;
+  font-weight: bold;
+  color: #3947C6;
+  background-color: #E5E7F5;
+  padding: 6px 12px;
+  border-radius: 4px;
+}
+
+.mp-content-section h4,
+.mp-content-section h5,
+.mp-content-section h6 {
+  margin: 20px 0 10px;
+  font-size: 1em;
+  font-weight: bold;
+  color: #333;
+}
+
+/* ========== 段落 ========== */
+.mp-content-section p {
+  margin: 1em 0;
+  line-height: 1.8;
+  text-align: justify;
+  color: #333;
+}
+
+/* ========== 列表 ========== */
+.mp-content-section ul,
+.mp-content-section ol {
+  padding-left: 2em;
+  margin: 1em 0;
+}
+
+.mp-content-section li {
+  margin: 0.4em 0;
+  line-height: 1.8;
+  color: #333;
+}
+
+/* ========== 引用：蓝色左边框 + 浅灰蓝背景 ========== */
+.mp-content-section blockquote {
+  border-left: 4px solid #3478f6;
+  padding: 14px 20px;
+  background: #f0f4f8;
+  margin: 1em 0;
+  color: #333;
+  font-style: normal;
+  border-radius: 0 8px 8px 0;
+}
+
+.mp-content-section blockquote p {
+  margin: 0.5em 0;
+  line-height: 1.8;
+}
+
+/* ========== 代码块 ========== */
+.mp-content-section pre {
+  background: #F8F8F8;
+  border: 1px solid #E8E7E4;
+  border-radius: 4px;
+  padding: 1em;
+  margin: 1.2em 0;
+  font-size: 13px;
+  line-height: 1.6;
+  overflow-x: auto;
+}
+
+.mp-content-section pre .mp-code-header {
+  margin-bottom: 0.8em;
+  display: flex;
+  gap: 6px;
+}
+
+.mp-content-section pre .mp-code-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+}
+
+.mp-content-section pre .mp-code-dot:nth-child(1) { background-color: #fc8181; }
+.mp-content-section pre .mp-code-dot:nth-child(2) { background-color: #f6e05e; }
+.mp-content-section pre .mp-code-dot:nth-child(3) { background-color: #68d391; }
+
+.mp-content-section code:not(pre code) {
+  background: #F9F8F7;
+  padding: 2px 5px;
+  border-radius: 3px;
+  color: #BF7067;
+  font-size: 0.9em;
+}
+
+/* ========== 链接 ========== */
+.mp-content-section a {
+  color: #2b6cb0;
+  text-decoration: none;
+  border-bottom: 1px solid #2b6cb0;
+}
+
+/* ========== 强调样式 ========== */
+
+/* 加粗：适配明暗模式 */
+.mp-content-section strong {
+  font-weight: bold;
+  color: #000000;
+}
+
+@media (prefers-color-scheme: dark) {
+  .mp-content-section strong {
+    color: #ffffff;
+  }
+}
+
+/* 斜体：蓝色 */
+.mp-content-section em {
+  font-style: italic;
+  color: #2b6cb0;
+}
+
+/* 删除线 */
+.mp-content-section del {
+  text-decoration: line-through;
+  color: #a0aec0;
+}
+
+/* 高亮：背景色 #F9DB6B */
+.mp-content-section mark {
+  background-color: #F9DB6B;
+  padding: 2px 4px;
+  border-radius: 2px;
+}
+
+/* ========== 表格 ========== */
+.mp-content-section table {
+  width: 100%;
+  margin: 1em 0;
+  border-collapse: collapse;
+  border: 1px solid #e2e8f0;
+}
+
+.mp-content-section th {
+  background: #f0f4f8;
+  font-weight: bold;
+  color: #333;
+  padding: 10px 12px;
+  border: 1px solid #e2e8f0;
+  text-align: left;
+}
+
+.mp-content-section td {
+  padding: 10px 12px;
+  border: 1px solid #e2e8f0;
+  color: #333;
+}
+
+.mp-content-section tr:nth-child(even) {
+  background-color: #f7fafc;
+}
+
+/* ========== 分隔线 ========== */
+.mp-content-section hr {
+  border: none;
+  border-top: 1px solid #e2e8f0;
+  margin: 24px 0;
+}
+
+/* ========== 图片 ========== */
+.mp-content-section img {
+  max-width: 100%;
+  height: auto;
+  display: block;
+  margin: 1.5em auto;
+}
+
+/* ========== 脚注 ========== */
+.mp-content-section .footnote-ref,
+.mp-content-section .footnote-backref {
+  color: #2b6cb0;
+  text-decoration: none;
+  font-size: 0.85em;
+  vertical-align: super;
+}

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "mp-publisher",
 	"name": "MP Publisher",
-	"version": "2.2.4",
+	"version": "2.2.5",
 	"minAppVersion": "0.15.0",
 	"description": "Preview with custom CSS themes and publish articles to WeChat Official Accounts (微信公众号) with one click.",
 	"author": "joeytoday",

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -223,18 +223,12 @@ export async function markdownToHtml(
         // 格式化内容（创建 section 容器、处理代码块等）
         MPConverter.formatContent(tempDiv);
 
-        // 应用主题 CSS
-        if (themeManager) {
-            const section = tempDiv.querySelector('.mp-content-section') as HTMLElement;
-            if (section) {
-                themeManager.applyTheme(section);
-            }
-        }
-
         // 移除定位样式
         tempDiv.removeAttribute('style');
 
-        // 获取主题 CSS 用于 juice 内联
+        // 获取主题 CSS 用于 juice 内联（不通过 applyTheme 注入 <style> 标签，
+        // 而是直接通过 juice 将 CSS 内联到每个元素的 style 属性上，
+        // 确保公众号后台和跨设备粘贴时样式不丢失）
         const themeCSS = themeManager ? themeManager.getActiveThemeCSS() : '';
 
         // 序列化 HTML

--- a/src/copyManager.ts
+++ b/src/copyManager.ts
@@ -1,32 +1,56 @@
 import { Notice } from 'obsidian';
 
 export class CopyManager {
-    private static cleanupHtml(element: HTMLElement): string {
-        // 创建克隆以避免修改原始元素
-        const clone = element.cloneNode(true) as HTMLElement;
+    /**
+     * 提取 <style> 标签中的 CSS 内容
+     */
+    private static extractStyleCSS(element: HTMLElement): string {
+        const styleTags = element.querySelectorAll('style');
+        const cssFragments: string[] = [];
+        styleTags.forEach(tag => {
+            if (tag.textContent) {
+                cssFragments.push(tag.textContent);
+            }
+        });
+        return cssFragments.join('\n');
+    }
 
-        // 移除所有的 data-* 属性
-        clone.querySelectorAll('*').forEach(el => {
+    /**
+     * 使用 juice 将 CSS 内联到 HTML 元素的 style 属性上，
+     * 确保跨平台粘贴时样式一致
+     */
+    private static async inlineCSS(html: string, css: string): Promise<string> {
+        if (!css) return html;
+        try {
+            const { inlineContent } = await import('juice');
+            return inlineContent(html, css, {
+                applyStyleTags: true,
+                removeStyleTags: true,
+                preserveMediaQueries: false,
+                preserveFontFaces: false,
+            });
+        } catch (error) {
+            console.error('juice 内联 CSS 失败:', error);
+            return html;
+        }
+    }
+
+    /**
+     * 清理 HTML 中不需要的属性（在 CSS 已内联之后调用）
+     */
+    private static cleanupAttributes(element: HTMLElement): void {
+        element.querySelectorAll('*').forEach(el => {
+            // 移除 data-* 属性
             Array.from(el.attributes).forEach(attr => {
                 if (attr.name.startsWith('data-')) {
                     el.removeAttribute(attr.name);
                 }
             });
-        });
-
-        // 移除所有的 class 属性
-        clone.querySelectorAll('*').forEach(el => {
+            // 移除 id 属性
+            el.removeAttribute('id');
+            // 移除 class 属性（CSS 已内联，class 不再需要）
             el.removeAttribute('class');
         });
-
-        // 移除所有的 id 属性
-        clone.querySelectorAll('*').forEach(el => {
-            el.removeAttribute('id');
-        });
-
-        // 使用 XMLSerializer 安全地转换为字符串
-        const serializer = new XMLSerializer();
-        return serializer.serializeToString(clone);
     }
 
     private static async processImages(container: HTMLElement): Promise<void> {
@@ -61,17 +85,36 @@ export class CopyManager {
             if (!contentSection) {
                 throw new Error('找不到内容区域');
             }
-            // 使用新的 cleanupHtml 方法
-            const cleanHtml = this.cleanupHtml(contentSection as HTMLElement);
+
+            // 1. 提取 <style> 标签中的主题 CSS
+            const themeCSS = this.extractStyleCSS(contentSection as HTMLElement);
+
+            // 2. 移除 <style> 标签（后续由 juice 内联）
+            contentSection.querySelectorAll('style').forEach(tag => tag.remove());
+
+            // 3. 序列化为 HTML 字符串
+            const serializer = new XMLSerializer();
+            let rawHtml = serializer.serializeToString(contentSection);
+            rawHtml = rawHtml.replace(/ xmlns="http:\/\/www\.w3\.org\/1999\/xhtml"/g, '');
+
+            // 4. 使用 juice 将 CSS 内联到每个元素的 style 属性
+            let inlinedHtml = await this.inlineCSS(rawHtml, themeCSS);
+
+            // 5. 清理多余属性（data-*、id、class）
+            const tempContainer = document.createElement('div');
+            tempContainer.innerHTML = inlinedHtml;
+            this.cleanupAttributes(tempContainer);
+            const finalHtml = tempContainer.innerHTML;
 
             const clipData = new ClipboardItem({
-                'text/html': new Blob([cleanHtml], { type: 'text/html' }),
+                'text/html': new Blob([finalHtml], { type: 'text/html' }),
                 'text/plain': new Blob([clone.textContent || ''], { type: 'text/plain' })
             });
 
             await navigator.clipboard.write([clipData]);
             new Notice('已复制到剪贴板');
         } catch (error) {
+            console.error('复制失败:', error);
             new Notice('复制失败');
         }
     }

--- a/src/ui/modals.ts
+++ b/src/ui/modals.ts
@@ -496,39 +496,14 @@ export class PublishModal extends Modal {
 				return;
 			}
 
-			// 从预览视图获取已渲染的HTML内容（保持样式一致）
-			const previewLeaves = this.app.workspace.getLeavesOfType('mp-preview');
-			let htmlContent = '';
-			
-			if (previewLeaves.length > 0) {
-				const previewView = previewLeaves[0].view as any;
-				if (previewView && previewView.previewEl) {
-					// 克隆预览内容以避免影响预览视图
-					const clonedContent = previewView.previewEl.cloneNode(true) as HTMLElement;
-					
-					// 序列化为HTML字符串
-					const serializer = new XMLSerializer();
-					let serializedHtml = '';
-					Array.from(clonedContent.children).forEach((child) => {
-						serializedHtml += serializer.serializeToString(child);
-					});
-					htmlContent = serializedHtml.replace(/ xmlns="http:\/\/www\.w3\.org\/1999\/xhtml"/g, '');
-					
-					this.plugin.logger.debug('使用预览视图的渲染内容发布');
-				}
-			}
-			
-			// 如果没有预览视图，降级使用默认渲染
-			if (!htmlContent) {
-				this.plugin.logger.warn('未找到预览视图，使用默认渲染');
-				const content = this.markdownView.getViewData();
-				htmlContent = await markdownToHtml(
-					this.app,
-					content,
-					this.markdownView.file?.path || '',
-					this.plugin.themeManager,
-				);
-			}
+			// 使用 markdownToHtml 渲染内容（通过 juice 内联 CSS，确保样式在公众号后台正确显示）
+			const content = this.markdownView.getViewData();
+			const htmlContent = await markdownToHtml(
+				this.app,
+				content,
+				this.markdownView.file?.path || '',
+				this.plugin.themeManager,
+			);
 
 			if (platform === 'wechat') {
 				if (!this.plugin.settings.wechatAppId || !this.plugin.settings.wechatAppSecret) {


### PR DESCRIPTION
- Refactor CopyManager to extract and inline CSS using juice library
- Remove applyTheme calls in converter.ts, use juice for CSS inlining instead
- Simplify publish modal to use markdownToHtml directly
- Add colorful.css custom theme file
- Update .gitignore to remove custom/ exclusion

This ensures styles are preserved when copying to WeChat Official Account or other platforms