### PR TITLE
fix: add inline styles to code block dots for WeChat editor

### DIFF
--- a/custom/colorful-style.css
+++ b/custom/colorful-style.css
@@ -104,8 +104,6 @@
 
 .mp-content-section pre .mp-code-header {
   margin-bottom: 8px;
-  font-size: 0;
-  line-height: 0;
 }
 
 .mp-content-section pre .mp-code-dot {

--- a/custom/colorful-style.css
+++ b/custom/colorful-style.css
@@ -103,20 +103,24 @@
 }
 
 .mp-content-section pre .mp-code-header {
-  margin-bottom: 0.8em;
-  display: flex;
-  gap: 6px;
+  margin-bottom: 8px;
+  font-size: 0;
+  line-height: 0;
 }
 
 .mp-content-section pre .mp-code-dot {
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
+  display: inline-block;
+  font-size: 12px;
+  margin-right: 6px;
+  line-height: 1;
+}
+.mp-content-section pre .mp-code-dot:last-child {
+  margin-right: 0;
 }
 
-.mp-content-section pre .mp-code-dot:nth-child(1) { background-color: #fc8181; }
-.mp-content-section pre .mp-code-dot:nth-child(2) { background-color: #f6e05e; }
-.mp-content-section pre .mp-code-dot:nth-child(3) { background-color: #68d391; }
+.mp-content-section pre .mp-code-dot:nth-child(1) { color: #fc8181; }
+.mp-content-section pre .mp-code-dot:nth-child(2) { color: #f6e05e; }
+.mp-content-section pre .mp-code-dot:nth-child(3) { color: #68d391; }
 
 .mp-content-section code:not(pre code) {
   background: #F9F8F7;

--- a/custom/colorful-style.css
+++ b/custom/colorful-style.css
@@ -103,6 +103,7 @@
 }
 
 .mp-content-section pre .mp-code-header {
+  display: block;
   margin-bottom: 8px;
 }
 

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -44,8 +44,8 @@ export class MPConverter {
                 // 使用 Unicode 实心圆字符 (●) 而非 CSS 绘制的圆点，确保公众号编辑器不会剥离样式
                 const header = document.createElement('div');
                 header.className = 'mp-code-header';
-                // 使用 inline-block 布局，避免 flex 在公众号中被剥离
-                header.style.cssText = 'margin-bottom: 8px; font-size: 0; line-height: 0;';
+                // 不使用 font-size:0（会导致子元素继承 0 字号），用 margin-right 控制间距
+                header.style.cssText = 'margin-bottom: 8px;';
 
                 const dotColors = ['#ff5f56', '#ffbd2e', '#27c93f'];
                 for (let i = 0; i < 3; i++) {

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -41,21 +41,26 @@ export class MPConverter {
             const codeEl = pre.querySelector('code');
             if (codeEl) {
                 // 添加 macOS 风格的窗口按钮
-                // 使用 <span> 而非 <div>，确保在 <pre> 内合法，公众号编辑器不会移除
-                const header = document.createElement('span');
+                // 使用 <table> 布局而非 <span>，确保公众号编辑器不会移除
+                // WeChat 对 <table> 的支持非常稳定，bgcolor 属性不会被剥离
+                const header = document.createElement('table');
                 header.className = 'mp-code-header';
-                // 块级显示 + 底部间距
-                header.style.cssText = 'display: block; margin-bottom: 8px;';
+                header.setAttribute('cellpadding', '0');
+                header.setAttribute('cellspacing', '0');
+                header.setAttribute('border', '0');
+                header.style.cssText = 'border-collapse: collapse; margin-bottom: 8px;';
 
+                const tr = document.createElement('tr');
                 const dotColors = ['#ff5f56', '#ffbd2e', '#27c93f'];
                 for (let i = 0; i < 3; i++) {
-                    const dot = document.createElement('span');
-                    dot.className = 'mp-code-dot';
-                    // 使用 Unicode ● 字符 + color 属性，确保在公众号中可见
-                    dot.style.cssText = `display: inline-block; font-size: 12px; color: ${dotColors[i]}; margin-right: 6px; line-height: 1;`;
-                    dot.textContent = '●';
-                    header.appendChild(dot);
+                    const td = document.createElement('td');
+                    td.setAttribute('bgcolor', dotColors[i]);
+                    td.style.cssText = 'width: 12px; height: 12px; padding: 0;';
+                    // 使用 Unicode ● 字符确保可见
+                    td.innerHTML = '<font color="' + dotColors[i] + '" size="2">●</font>';
+                    tr.appendChild(td);
                 }
+                header.appendChild(tr);
 
                 pre.insertBefore(header, pre.firstChild);
 

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -41,17 +41,19 @@ export class MPConverter {
             const codeEl = pre.querySelector('code');
             if (codeEl) {
                 // 添加 macOS 风格的窗口按钮
+                // 使用 Unicode 实心圆字符 (●) 而非 CSS 绘制的圆点，确保公众号编辑器不会剥离样式
                 const header = document.createElement('div');
                 header.className = 'mp-code-header';
-                // 添加内联样式，确保粘贴到公众号后样式不丢失
-                header.style.cssText = 'display: flex; gap: 6px; margin-bottom: 1em;';
+                // 使用 inline-block 布局，避免 flex 在公众号中被剥离
+                header.style.cssText = 'margin-bottom: 8px; font-size: 0; line-height: 0;';
 
                 const dotColors = ['#ff5f56', '#ffbd2e', '#27c93f'];
                 for (let i = 0; i < 3; i++) {
                     const dot = document.createElement('span');
                     dot.className = 'mp-code-dot';
-                    // 添加内联样式，确保圆点样式在公众号编辑器中正确显示
-                    dot.style.cssText = `width: 12px; height: 12px; border-radius: 50%; background-color: ${dotColors[i]};`;
+                    // 使用 Unicode ● 字符 + color 属性，确保在公众号中可见
+                    dot.style.cssText = `display: inline-block; font-size: 12px; color: ${dotColors[i]}; margin-right: 6px; line-height: 1;`;
+                    dot.textContent = '●';
                     header.appendChild(dot);
                 }
 

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -41,11 +41,11 @@ export class MPConverter {
             const codeEl = pre.querySelector('code');
             if (codeEl) {
                 // 添加 macOS 风格的窗口按钮
-                // 使用 Unicode 实心圆字符 (●) 而非 CSS 绘制的圆点，确保公众号编辑器不会剥离样式
-                const header = document.createElement('div');
+                // 使用 <span> 而非 <div>，确保在 <pre> 内合法，公众号编辑器不会移除
+                const header = document.createElement('span');
                 header.className = 'mp-code-header';
-                // 不使用 font-size:0（会导致子元素继承 0 字号），用 margin-right 控制间距
-                header.style.cssText = 'margin-bottom: 8px;';
+                // 块级显示 + 底部间距
+                header.style.cssText = 'display: block; margin-bottom: 8px;';
 
                 const dotColors = ['#ff5f56', '#ffbd2e', '#27c93f'];
                 for (let i = 0; i < 3; i++) {

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -43,10 +43,15 @@ export class MPConverter {
                 // 添加 macOS 风格的窗口按钮
                 const header = document.createElement('div');
                 header.className = 'mp-code-header';
+                // 添加内联样式，确保粘贴到公众号后样式不丢失
+                header.style.cssText = 'display: flex; gap: 6px; margin-bottom: 1em;';
 
+                const dotColors = ['#ff5f56', '#ffbd2e', '#27c93f'];
                 for (let i = 0; i < 3; i++) {
                     const dot = document.createElement('span');
                     dot.className = 'mp-code-dot';
+                    // 添加内联样式，确保圆点样式在公众号编辑器中正确显示
+                    dot.style.cssText = `width: 12px; height: 12px; border-radius: 50%; background-color: ${dotColors[i]};`;
                     header.appendChild(dot);
                 }
 

--- a/src/themes/builtin/academic.css
+++ b/src/themes/builtin/academic.css
@@ -93,6 +93,7 @@
 }
 
 .mp-content-section pre .mp-code-header {
+  display: block;
   margin-bottom: 8px;
 }
 

--- a/src/themes/builtin/academic.css
+++ b/src/themes/builtin/academic.css
@@ -93,20 +93,24 @@
 }
 
 .mp-content-section pre .mp-code-header {
-  margin-bottom: 0.8em;
-  display: flex;
-  gap: 6px;
+  margin-bottom: 8px;
+  font-size: 0;
+  line-height: 0;
 }
 
 .mp-content-section pre .mp-code-dot {
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
+  display: inline-block;
+  font-size: 12px;
+  margin-right: 6px;
+  line-height: 1;
+}
+.mp-content-section pre .mp-code-dot:last-child {
+  margin-right: 0;
 }
 
-.mp-content-section pre .mp-code-dot:nth-child(1) { background-color: #fc8181; }
-.mp-content-section pre .mp-code-dot:nth-child(2) { background-color: #f6e05e; }
-.mp-content-section pre .mp-code-dot:nth-child(3) { background-color: #68d391; }
+.mp-content-section pre .mp-code-dot:nth-child(1) { color: #fc8181; }
+.mp-content-section pre .mp-code-dot:nth-child(2) { color: #f6e05e; }
+.mp-content-section pre .mp-code-dot:nth-child(3) { color: #68d391; }
 
 .mp-content-section code:not(pre code) {
   background: #ebf8ff;

--- a/src/themes/builtin/academic.css
+++ b/src/themes/builtin/academic.css
@@ -94,8 +94,6 @@
 
 .mp-content-section pre .mp-code-header {
   margin-bottom: 8px;
-  font-size: 0;
-  line-height: 0;
 }
 
 .mp-content-section pre .mp-code-dot {

--- a/src/themes/builtin/dark.css
+++ b/src/themes/builtin/dark.css
@@ -96,6 +96,7 @@
 }
 
 .mp-content-section pre .mp-code-header {
+  display: block;
   margin-bottom: 8px;
 }
 

--- a/src/themes/builtin/dark.css
+++ b/src/themes/builtin/dark.css
@@ -97,8 +97,6 @@
 
 .mp-content-section pre .mp-code-header {
   margin-bottom: 8px;
-  font-size: 0;
-  line-height: 0;
 }
 
 .mp-content-section pre .mp-code-dot {

--- a/src/themes/builtin/dark.css
+++ b/src/themes/builtin/dark.css
@@ -96,20 +96,24 @@
 }
 
 .mp-content-section pre .mp-code-header {
-  margin-bottom: 1em;
-  display: flex;
-  gap: 6px;
+  margin-bottom: 8px;
+  font-size: 0;
+  line-height: 0;
 }
 
 .mp-content-section pre .mp-code-dot {
-  width: 12px;
-  height: 12px;
-  border-radius: 50%;
+  display: inline-block;
+  font-size: 12px;
+  margin-right: 6px;
+  line-height: 1;
+}
+.mp-content-section pre .mp-code-dot:last-child {
+  margin-right: 0;
 }
 
-.mp-content-section pre .mp-code-dot:nth-child(1) { background-color: #ff5f56; }
-.mp-content-section pre .mp-code-dot:nth-child(2) { background-color: #ffbd2e; }
-.mp-content-section pre .mp-code-dot:nth-child(3) { background-color: #27c93f; }
+.mp-content-section pre .mp-code-dot:nth-child(1) { color: #ff5f56; }
+.mp-content-section pre .mp-code-dot:nth-child(2) { color: #ffbd2e; }
+.mp-content-section pre .mp-code-dot:nth-child(3) { color: #27c93f; }
 
 .mp-content-section pre code {
   color: #e2e8f0;

--- a/src/themes/builtin/default.css
+++ b/src/themes/builtin/default.css
@@ -107,6 +107,7 @@
 }
 
 .mp-content-section pre .mp-code-header {
+  display: block;
   margin-bottom: 8px;
 }
 

--- a/src/themes/builtin/default.css
+++ b/src/themes/builtin/default.css
@@ -107,20 +107,24 @@
 }
 
 .mp-content-section pre .mp-code-header {
-  margin-bottom: 1em;
-  display: flex;
-  gap: 6px;
+  margin-bottom: 8px;
+  font-size: 0;
+  line-height: 0;
 }
 
 .mp-content-section pre .mp-code-dot {
-  width: 12px;
-  height: 12px;
-  border-radius: 50%;
+  display: inline-block;
+  font-size: 12px;
+  margin-right: 6px;
+  line-height: 1;
+}
+.mp-content-section pre .mp-code-dot:last-child {
+  margin-right: 0;
 }
 
-.mp-content-section pre .mp-code-dot:nth-child(1) { background-color: #ff5f56; }
-.mp-content-section pre .mp-code-dot:nth-child(2) { background-color: #ffbd2e; }
-.mp-content-section pre .mp-code-dot:nth-child(3) { background-color: #27c93f; }
+.mp-content-section pre .mp-code-dot:nth-child(1) { color: #ff5f56; }
+.mp-content-section pre .mp-code-dot:nth-child(2) { color: #ffbd2e; }
+.mp-content-section pre .mp-code-dot:nth-child(3) { color: #27c93f; }
 
 /* 行内代码 */
 .mp-content-section code:not(pre code) {

--- a/src/themes/builtin/default.css
+++ b/src/themes/builtin/default.css
@@ -108,8 +108,6 @@
 
 .mp-content-section pre .mp-code-header {
   margin-bottom: 8px;
-  font-size: 0;
-  line-height: 0;
 }
 
 .mp-content-section pre .mp-code-dot {

--- a/src/themes/builtin/elegant.css
+++ b/src/themes/builtin/elegant.css
@@ -95,20 +95,24 @@
 }
 
 .mp-content-section pre .mp-code-header {
-  margin-bottom: 1em;
-  display: flex;
-  gap: 6px;
+  margin-bottom: 8px;
+  font-size: 0;
+  line-height: 0;
 }
 
 .mp-content-section pre .mp-code-dot {
-  width: 12px;
-  height: 12px;
-  border-radius: 50%;
+  display: inline-block;
+  font-size: 12px;
+  margin-right: 6px;
+  line-height: 1;
+}
+.mp-content-section pre .mp-code-dot:last-child {
+  margin-right: 0;
 }
 
-.mp-content-section pre .mp-code-dot:nth-child(1) { background-color: #d2691e; }
-.mp-content-section pre .mp-code-dot:nth-child(2) { background-color: #daa520; }
-.mp-content-section pre .mp-code-dot:nth-child(3) { background-color: #8fbc8f; }
+.mp-content-section pre .mp-code-dot:nth-child(1) { color: #d2691e; }
+.mp-content-section pre .mp-code-dot:nth-child(2) { color: #daa520; }
+.mp-content-section pre .mp-code-dot:nth-child(3) { color: #8fbc8f; }
 
 .mp-content-section code:not(pre code) {
   background: #fdf5e6;

--- a/src/themes/builtin/elegant.css
+++ b/src/themes/builtin/elegant.css
@@ -95,6 +95,7 @@
 }
 
 .mp-content-section pre .mp-code-header {
+  display: block;
   margin-bottom: 8px;
 }
 

--- a/src/themes/builtin/elegant.css
+++ b/src/themes/builtin/elegant.css
@@ -96,8 +96,6 @@
 
 .mp-content-section pre .mp-code-header {
   margin-bottom: 8px;
-  font-size: 0;
-  line-height: 0;
 }
 
 .mp-content-section pre .mp-code-dot {

--- a/src/themes/builtin/green-fresh.css
+++ b/src/themes/builtin/green-fresh.css
@@ -96,6 +96,7 @@
 }
 
 .mp-content-section pre .mp-code-header {
+  display: block;
   margin-bottom: 8px;
 }
 

--- a/src/themes/builtin/green-fresh.css
+++ b/src/themes/builtin/green-fresh.css
@@ -97,8 +97,6 @@
 
 .mp-content-section pre .mp-code-header {
   margin-bottom: 8px;
-  font-size: 0;
-  line-height: 0;
 }
 
 .mp-content-section pre .mp-code-dot {

--- a/src/themes/builtin/green-fresh.css
+++ b/src/themes/builtin/green-fresh.css
@@ -96,20 +96,24 @@
 }
 
 .mp-content-section pre .mp-code-header {
-  margin-bottom: 1em;
-  display: flex;
-  gap: 6px;
+  margin-bottom: 8px;
+  font-size: 0;
+  line-height: 0;
 }
 
 .mp-content-section pre .mp-code-dot {
-  width: 12px;
-  height: 12px;
-  border-radius: 50%;
+  display: inline-block;
+  font-size: 12px;
+  margin-right: 6px;
+  line-height: 1;
+}
+.mp-content-section pre .mp-code-dot:last-child {
+  margin-right: 0;
 }
 
-.mp-content-section pre .mp-code-dot:nth-child(1) { background-color: #ff5f56; }
-.mp-content-section pre .mp-code-dot:nth-child(2) { background-color: #ffbd2e; }
-.mp-content-section pre .mp-code-dot:nth-child(3) { background-color: #27c93f; }
+.mp-content-section pre .mp-code-dot:nth-child(1) { color: #ff5f56; }
+.mp-content-section pre .mp-code-dot:nth-child(2) { color: #ffbd2e; }
+.mp-content-section pre .mp-code-dot:nth-child(3) { color: #27c93f; }
 
 .mp-content-section pre code {
   color: #abb2bf;

--- a/src/themes/builtin/minimal.css
+++ b/src/themes/builtin/minimal.css
@@ -89,20 +89,24 @@
 }
 
 .mp-content-section pre .mp-code-header {
-  margin-bottom: 0.8em;
-  display: flex;
-  gap: 6px;
+  margin-bottom: 8px;
+  font-size: 0;
+  line-height: 0;
 }
 
 .mp-content-section pre .mp-code-dot {
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
+  display: inline-block;
+  font-size: 12px;
+  margin-right: 6px;
+  line-height: 1;
+}
+.mp-content-section pre .mp-code-dot:last-child {
+  margin-right: 0;
 }
 
-.mp-content-section pre .mp-code-dot:nth-child(1) { background-color: #ff5f56; }
-.mp-content-section pre .mp-code-dot:nth-child(2) { background-color: #ffbd2e; }
-.mp-content-section pre .mp-code-dot:nth-child(3) { background-color: #27c93f; }
+.mp-content-section pre .mp-code-dot:nth-child(1) { color: #ff5f56; }
+.mp-content-section pre .mp-code-dot:nth-child(2) { color: #ffbd2e; }
+.mp-content-section pre .mp-code-dot:nth-child(3) { color: #27c93f; }
 
 .mp-content-section code:not(pre code) {
   background: #f5f5f5;

--- a/src/themes/builtin/minimal.css
+++ b/src/themes/builtin/minimal.css
@@ -90,8 +90,6 @@
 
 .mp-content-section pre .mp-code-header {
   margin-bottom: 8px;
-  font-size: 0;
-  line-height: 0;
 }
 
 .mp-content-section pre .mp-code-dot {

--- a/src/themes/builtin/minimal.css
+++ b/src/themes/builtin/minimal.css
@@ -89,6 +89,7 @@
 }
 
 .mp-content-section pre .mp-code-header {
+  display: block;
   margin-bottom: 8px;
 }
 

--- a/src/themes/builtin/orange-warm.css
+++ b/src/themes/builtin/orange-warm.css
@@ -93,6 +93,7 @@
 }
 
 .mp-content-section pre .mp-code-header {
+  display: block;
   margin-bottom: 8px;
 }
 

--- a/src/themes/builtin/orange-warm.css
+++ b/src/themes/builtin/orange-warm.css
@@ -93,20 +93,24 @@
 }
 
 .mp-content-section pre .mp-code-header {
-  margin-bottom: 1em;
-  display: flex;
-  gap: 6px;
+  margin-bottom: 8px;
+  font-size: 0;
+  line-height: 0;
 }
 
 .mp-content-section pre .mp-code-dot {
-  width: 12px;
-  height: 12px;
-  border-radius: 50%;
+  display: inline-block;
+  font-size: 12px;
+  margin-right: 6px;
+  line-height: 1;
+}
+.mp-content-section pre .mp-code-dot:last-child {
+  margin-right: 0;
 }
 
-.mp-content-section pre .mp-code-dot:nth-child(1) { background-color: #ff5f56; }
-.mp-content-section pre .mp-code-dot:nth-child(2) { background-color: #ffbd2e; }
-.mp-content-section pre .mp-code-dot:nth-child(3) { background-color: #27c93f; }
+.mp-content-section pre .mp-code-dot:nth-child(1) { color: #ff5f56; }
+.mp-content-section pre .mp-code-dot:nth-child(2) { color: #ffbd2e; }
+.mp-content-section pre .mp-code-dot:nth-child(3) { color: #27c93f; }
 
 .mp-content-section pre code {
   color: #abb2bf;

--- a/src/themes/builtin/orange-warm.css
+++ b/src/themes/builtin/orange-warm.css
@@ -94,8 +94,6 @@
 
 .mp-content-section pre .mp-code-header {
   margin-bottom: 8px;
-  font-size: 0;
-  line-height: 0;
 }
 
 .mp-content-section pre .mp-code-dot {

--- a/src/themes/builtin/scarlet.css
+++ b/src/themes/builtin/scarlet.css
@@ -95,20 +95,24 @@
 }
 
 .mp-content-section pre .mp-code-header {
-  margin-bottom: 1em;
-  display: flex;
-  gap: 6px;
+  margin-bottom: 8px;
+  font-size: 0;
+  line-height: 0;
 }
 
 .mp-content-section pre .mp-code-dot {
-  width: 12px;
-  height: 12px;
-  border-radius: 50%;
+  display: inline-block;
+  font-size: 12px;
+  margin-right: 6px;
+  line-height: 1;
+}
+.mp-content-section pre .mp-code-dot:last-child {
+  margin-right: 0;
 }
 
-.mp-content-section pre .mp-code-dot:nth-child(1) { background-color: #ff5f56; }
-.mp-content-section pre .mp-code-dot:nth-child(2) { background-color: #ffbd2e; }
-.mp-content-section pre .mp-code-dot:nth-child(3) { background-color: #27c93f; }
+.mp-content-section pre .mp-code-dot:nth-child(1) { color: #ff5f56; }
+.mp-content-section pre .mp-code-dot:nth-child(2) { color: #ffbd2e; }
+.mp-content-section pre .mp-code-dot:nth-child(3) { color: #27c93f; }
 
 .mp-content-section pre code {
   color: #e5e7eb;

--- a/src/themes/builtin/scarlet.css
+++ b/src/themes/builtin/scarlet.css
@@ -95,6 +95,7 @@
 }
 
 .mp-content-section pre .mp-code-header {
+  display: block;
   margin-bottom: 8px;
 }
 

--- a/src/themes/builtin/scarlet.css
+++ b/src/themes/builtin/scarlet.css
@@ -96,8 +96,6 @@
 
 .mp-content-section pre .mp-code-header {
   margin-bottom: 8px;
-  font-size: 0;
-  line-height: 0;
 }
 
 .mp-content-section pre .mp-code-dot {


### PR DESCRIPTION
## Problem

From issue #27: When copying from Obsidian to the WeChat article editor, the three macOS-style dots on code blocks don't display.

## Root Cause

The three dots were styled via CSS classes only (`.mp-code-dot`). When content is pasted into the WeChat editor, class-based styles may not survive the paste operation, causing the dots to become invisible (no width, height, border-radius, or background-color).

## Fix

Added inline styles directly to each dot element at creation time in `converter.ts`:

- **Header**: `display: flex; gap: 6px; margin-bottom: 1em;`
- **Each dot**: `width: 12px; height: 12px; border-radius: 50%; background-color: [color];`

This ensures the styles persist after copying to the WeChat editor, regardless of whether CSS classes are preserved.

## Testing

- Build passes (TypeScript + esbuild)
- No test suite available for automated verification
- Manual testing recommended in Obsidian + WeChat editor