### PR TITLE
2.6.2: 补充修复 Obsidian 插件 review 剩余 lint 问题

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [2.6.2] - 2026-06-24
+
+### 🔧 代码规范
+
+- 微信 API 响应定义精确接口类型，替代 `any` 直接访问
+- `JSON.parse` 结果添加类型标注（素材缓存、Token 缓存、sessionStorage 数据）
+- `catch (error)` 改为 `catch (error: unknown)`，用 `instanceof Error` 替代直接访问属性
+- Logger 方法参数 `any[]` → `unknown[]`
+- `setCssProps` 使用 camelCase 属性名（`pointerEvents`）
+- Promise 调用加 `void` 前缀，避免未处理警告
+- 移除 `asWechatResponse` 辅助函数（含禁止的 eslint-disable）
+- 移除未使用的 `parseCssString` 导入
+- `text-indent: 0px` → `text-indent: 0`（兼容性）
+- README 补充英文安装说明和使用指南
+- ConfirmModal 支持 async onConfirm 回调
+
+---
+
 ## [2.6.1] - 2026-06-24
 
 ### 🔧 代码规范

--- a/README.md
+++ b/README.md
@@ -6,6 +6,50 @@ https://github.com/user-attachments/assets/b62e82a0-9b3c-4406-8007-1bbb6b9b7bac
 
 **English description** | [中文说明](#-功能特点)
 
+## 🌟 Overview
+
+MP Publisher is an Obsidian plugin for writing and publishing articles to WeChat Official Account (微信公众号). It provides real-time preview with customizable CSS themes, one-click copy/paste to the WeChat editor, and direct API publishing to the draft box.
+
+**Key features:**
+- **8 built-in CSS themes** + local custom themes via `custom/` folder
+- **Theme management view** — browse, switch, create, edit, rename, delete themes
+- **Real-time preview** — see your article as it will appear in WeChat
+- **Smart publishing** — upload images, select cover art, create/update drafts via WeChat API
+- **One-click copy** — formatted HTML with inline CSS, paste directly into the WeChat editor
+- **LaTeX math** — renders `$...$` / `$$...$$` formulas as PNG images
+- **30+ Callout types** — note, tip, warning, danger, etc. with theme-adapted styling
+- **Multi-account support** — manage multiple WeChat Official Accounts
+
+📖 Read the [CSS Theme Guide](./CSS_THEME_GUIDE.md) before writing custom themes.
+
+## 📦 Installation
+
+### Via BRAT (recommended)
+1. Install [BRAT](https://github.com/TfTHacker/obsidian42-brat) from Obsidian community plugins
+2. Open BRAT settings → **Add beta plugin**
+3. Paste: `https://github.com/joeytoday/obsidian-mp-publisher`
+4. Confirm and enable the plugin in Obsidian settings
+
+### Manual installation
+1. Download `mp-publisher.zip` from [Releases](https://github.com/joeytoday/obsidian-mp-publisher/releases)
+2. Unzip into `<vault>/.obsidian/plugins/`
+3. Reload Obsidian and enable the plugin
+
+## 🚀 Quick Start
+
+### Step 1: Configure WeChat API
+1. Log into [WeChat MP Platform](https://mp.weixin.qq.com/) → Settings & Development → Basic Configuration
+2. Note your `AppID` and `AppSecret`
+3. Add your IP to the whitelist (or set `0.0.0.0/0` if your IP changes frequently)
+4. In Obsidian → Settings → MP Publisher, enter AppID and AppSecret
+
+### Step 2: Preview & Publish
+- **Preview**: Click the 📤 icon in the left sidebar, or run the command "Open MP Publisher"
+- **Copy**: Click "Copy to WeChat" → paste into the WeChat editor (Ctrl+V / Cmd+V)
+- **Publish**: Click "Publish" → enter title → select cover image → confirm
+
+Published articles appear in WeChat MP Platform → Content & Interaction → Drafts.
+
 ## ✨ Features
 
 ### 🎨 纯 CSS 主题系统

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "mp-publisher",
 	"name": "MP Publisher",
-	"version": "2.6.1",
+	"version": "2.6.2",
 	"minAppVersion": "1.13.0",
 	"description": "Preview with custom CSS themes and publish articles to WeChat Official Accounts with one click.",
 	"author": "joeytoday",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mp-publisher",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "description": "公众号发布插件，支持自定义样式预览和一键发布到微信公众号",
   "main": "main.js",
   "scripts": {

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -66,7 +66,7 @@ export class MPConverter {
         this.processCallouts(container);
 
         // 4. 处理图片
-        container.querySelectorAll('span.internal-embed[alt][src]').forEach(async el => {
+        container.querySelectorAll('span.internal-embed[alt][src]').forEach(el => {
             const originalSpan = el as HTMLElement;
             const src = originalSpan.getAttribute('src');
             const alt = originalSpan.getAttribute('alt');

--- a/src/copyManager.ts
+++ b/src/copyManager.ts
@@ -1,5 +1,4 @@
 import { Notice, requestUrl, sanitizeHTMLToDom } from 'obsidian';
-import { parseCssString } from './utils/css-props';
 import { processListItems } from './utils/dom-utils';
 
 export class CopyManager {

--- a/src/main.ts
+++ b/src/main.ts
@@ -135,7 +135,7 @@ export default class MPPublisherPlugin extends Plugin {
   async activateView() {
     const leaves = this.app.workspace.getLeavesOfType(VIEW_TYPE_MP);
     if (leaves.length > 0) {
-      this.app.workspace.revealLeaf(leaves[0]);
+      void this.app.workspace.revealLeaf(leaves[0]);
       return;
     }
 
@@ -153,7 +153,7 @@ export default class MPPublisherPlugin extends Plugin {
   async activateThemeManager() {
     const leaves = this.app.workspace.getLeavesOfType(VIEW_TYPE_THEME_MANAGER);
     if (leaves.length > 0) {
-      this.app.workspace.revealLeaf(leaves[0]);
+      void this.app.workspace.revealLeaf(leaves[0]);
       return;
     }
 

--- a/src/publisher/wechat.ts
+++ b/src/publisher/wechat.ts
@@ -20,6 +20,31 @@ interface TokenCache {
     expireTime: number;
 }
 
+// 微信 API 响应类型
+interface WechatBaseResponse {
+    errcode: number;
+    errmsg: string;
+}
+
+interface WechatTokenResponse extends WechatBaseResponse {
+    access_token?: string;
+}
+
+interface WechatUploadResponse extends WechatBaseResponse {
+    url?: string;
+    media_id?: string;
+}
+
+interface WechatDraftResponse extends WechatBaseResponse {
+    media_id?: string;
+    item?: Array<{ index: number; ad_count: number; }>;
+}
+
+interface WechatMaterialsResponse extends WechatBaseResponse {
+    item?: WechatMaterial[];
+    total_count?: number;
+}
+
 export class WechatPublisher {
     private app: App;
     private plugin: MPPlugin;
@@ -50,13 +75,15 @@ export class WechatPublisher {
                 });
             }, accountId);
 
-            if (materialsResponse.json.errcode && materialsResponse.json.errcode !== 0) {
-                this.handleWechatError(materialsResponse.json);
+            const data = materialsResponse.json as WechatMaterialsResponse;
+
+            if (data.errcode && data.errcode !== 0) {
+                this.handleWechatError(data);
                 return { items: [], totalCount: 0 };
             }
 
-            const items = materialsResponse.json.item || [];
-            const totalCount = materialsResponse.json.total_count || 0;
+            const items = data.item || [];
+            const totalCount = data.total_count || 0;
 
             // 更新缓存
             const cacheKey = `wechat_material_cache_page_${page}`;
@@ -87,7 +114,7 @@ export class WechatPublisher {
             if (mediaId) {
                 // 获取现有的上传图片缓存
                 const uploadedImagesCache = this.app.loadLocalStorage('wechat_uploaded_images_cache');
-                const uploadedImages = uploadedImagesCache ? JSON.parse(uploadedImagesCache) : {};
+                const uploadedImages: Record<string, { url: string; name: string; uploadTime: number }> = uploadedImagesCache ? JSON.parse(uploadedImagesCache) as Record<string, { url: string; name: string; uploadTime: number }> : {};
 
                 // 添加新上传的图片
                 uploadedImages[mediaId] = {
@@ -131,7 +158,7 @@ export class WechatPublisher {
         if (!forceRefresh) {
             try {
                 const cacheData = this.app.loadLocalStorage(cacheKey);
-                const cache: TokenCache = cacheData ? JSON.parse(cacheData) : null;
+                const cache: TokenCache | null = cacheData ? JSON.parse(cacheData) as TokenCache : null;
 
                 // 如果缓存存在且未过期（有效期为110分钟，微信令牌有效期为2小时）
                 if (cache && Date.now() < cache.expireTime) {
@@ -173,11 +200,13 @@ export class WechatPublisher {
                     }
                 });
 
-                if (!tokenResponse.json.access_token) {
-                    this.logger.error("获取微信访问令牌业务失败: ", tokenResponse.json);
-                    const errcode = tokenResponse.json.errcode;
-                    const errmsg = tokenResponse.json.errmsg || '未知错误';
-                    
+                const tokenData = tokenResponse.json as WechatTokenResponse;
+
+                if (!tokenData.access_token) {
+                    this.logger.error("获取微信访问令牌业务失败: ", tokenData);
+                    const errcode = tokenData.errcode;
+                    const errmsg = tokenData.errmsg || '未知错误';
+
                     // 业务失败通常不需要重试，除非是特定错误
                     if (attempt === maxRetries) {
                         // 针对 IP 白名单错误提供明确的提示
@@ -199,7 +228,7 @@ export class WechatPublisher {
                     continue; // 尝试重试
                 }
 
-                const accessToken = tokenResponse.json.access_token;
+                const accessToken = tokenData.access_token;
 
                 // 更新缓存（110分钟 = 6600000毫秒）
                 const expireTime = Date.now() + 6600000;
@@ -263,14 +292,16 @@ export class WechatPublisher {
 
             this.logger.debug(`response: ${JSON.stringify(response)}`);
 
-            if (response.json.errcode && response.json.errcode !== 0) {
-                this.handleWechatError(response.json);
-                throw new Error(response.json.errmsg);
+            const uploadData = response.json as WechatUploadResponse;
+
+            if (uploadData.errcode && uploadData.errcode !== 0) {
+                this.handleWechatError(uploadData);
+                throw new Error(uploadData.errmsg);
             }
 
             return {
-                url: response.json.url,
-                media_id: response.json.media_id
+                url: uploadData.url ?? '',
+                media_id: uploadData.media_id ?? ''
             };
         } catch (error) {
             this.logger.error('上传图片失败:', error);
@@ -359,7 +390,7 @@ export class WechatPublisher {
             if (codeEl.closest('pre')) return;
 
             const span = activeDocument.createElement('span');
-            const existingStyle = (codeEl as HTMLElement).getAttribute('style') || '';
+            const existingStyle = codeEl.getAttribute('style') || '';
             if (existingStyle) {
                 span.setCssProps(parseCssString(existingStyle));
             }
@@ -651,7 +682,8 @@ export class WechatPublisher {
             this.logger.debug(`response: ${JSON.stringify(response)}`);
 
             // 如果是 40007 错误且我们之前尝试更新现有草稿，可能是草稿 ID 已失效，清除它并重试一次创建新草稿
-            if (response.json && response.json.errcode === 40007 && metadata.draft?.media_id) {
+            const initialData = response.json as WechatDraftResponse;
+            if (initialData.errcode === 40007 && metadata.draft?.media_id) {
                 this.logger.warn('草稿 media_id 已失效，尝试重新创建新草稿');
                 metadata.draft.media_id = ''; // 清除失效的 ID
                 
@@ -679,17 +711,18 @@ export class WechatPublisher {
 
             if (response.status === 200) {
                 // 检查业务错误码
-                if (response.json.errcode && response.json.errcode !== 0) {
-                    this.handleWechatError(response.json);
+                const draftData = response.json as WechatDraftResponse;
+                if (draftData.errcode && draftData.errcode !== 0) {
+                    this.handleWechatError(draftData);
                     return false;
                 }
 
                 // 成功，更新元数据
-                if (response.json.media_id) {
-                    updateData.media_id = response.json.media_id;
+                if (draftData.media_id) {
+                    updateData.media_id = draftData.media_id;
                 }
-                if (response.json.item) {
-                    updateData.item = response.json.item;
+                if (draftData.item) {
+                    updateData.item = draftData.item;
                 }
 
                 updateDraftMetadata(metadata, updateData);
@@ -729,8 +762,9 @@ export class WechatPublisher {
                 let response = await requestFn(accessToken);
 
                 // 处理 Token 失效
-                if (response.json && [40001, 40014, 42001].includes(response.json.errcode)) {
-                    this.logger.warn(`Token失效 (${response.json.errcode})，尝试刷新并重试...`);
+                const tokenCheckData = response.json ? (response.json as WechatBaseResponse) : null;
+                if (tokenCheckData && [40001, 40014, 42001].includes(tokenCheckData.errcode)) {
+                    this.logger.warn(`Token失效 (${tokenCheckData.errcode})，尝试刷新并重试...`);
                     const newToken = await this.getAccessToken(true, accountId);
                     if (newToken) {
                         response = await requestFn(newToken);
@@ -757,9 +791,9 @@ export class WechatPublisher {
     }
 
     // 统一处理微信API错误
-    private handleWechatError(responseJson: Record<string, unknown>) {
-        const errcode = responseJson.errcode as number;
-        const errmsg = responseJson.errmsg as string;
+    private handleWechatError(responseJson: WechatBaseResponse) {
+        const errcode = responseJson.errcode;
+        const errmsg = responseJson.errmsg;
 
         let message = `微信API错误 (${errcode}): ${errmsg}`;
 

--- a/src/settings/ConfirmModal.ts
+++ b/src/settings/ConfirmModal.ts
@@ -2,9 +2,9 @@ import { App, Modal, Setting } from 'obsidian';
 
 export class ConfirmModal extends Modal {
     private message: string;
-    private onConfirm: () => void;
+    private onConfirm: () => void | Promise<void>;
 
-    constructor(app: App, title: string, message: string, onConfirm: () => void) {
+    constructor(app: App, title: string, message: string, onConfirm: () => void | Promise<void>) {
         super(app);
         this.titleEl.setText(title);
         this.message = message;
@@ -20,7 +20,7 @@ export class ConfirmModal extends Modal {
                 .setButtonText('确认')
                 .setCta()
                 .onClick(() => {
-                    this.onConfirm();
+                    void this.onConfirm();
                     this.close();
                 }))
             .addButton(btn => btn

--- a/src/settings/MPSettingTab.ts
+++ b/src/settings/MPSettingTab.ts
@@ -38,7 +38,7 @@ export class MPSettingTab extends PluginSettingTab {
             .addButton(btn => btn
                 .setButtonText('打开')
                 .onClick(() => {
-                    this.plugin.activateThemeManager();
+                    void this.plugin.activateThemeManager();
                 }));
 
         // ── 公众号 ──────────────────────────────────
@@ -215,7 +215,7 @@ export class MPSettingTab extends PluginSettingTab {
     private async openDocView(viewType: string): Promise<void> {
         const leaves = this.app.workspace.getLeavesOfType(viewType);
         if (leaves.length > 0) {
-            this.app.workspace.revealLeaf(leaves[0]);
+            void this.app.workspace.revealLeaf(leaves[0]);
             return;
         }
         const leaf = this.app.workspace.getLeaf(true);

--- a/src/themeManager.ts
+++ b/src/themeManager.ts
@@ -460,7 +460,7 @@ export class ThemeManager {
             });
 
             if (response.status === 200 && Array.isArray(response.json)) {
-                const themeIndex: RemoteThemeIndex[] = response.json;
+                const themeIndex = response.json as RemoteThemeIndex[];
 
                 // 更新缓存
                 await this.plugin.settingsManager.updateSettings({

--- a/src/themeManagerView.ts
+++ b/src/themeManagerView.ts
@@ -164,7 +164,7 @@ export class ThemeManagerView extends ItemView {
             }
         };
 
-        refreshButton.addEventListener('click', loadRemoteIndex);
+        refreshButton.addEventListener('click', () => void loadRemoteIndex());
         await loadRemoteIndex();
     }
 
@@ -520,7 +520,7 @@ export class ThemeManagerView extends ItemView {
 
         if (existingLeaves.length > 0) {
             leaf = existingLeaves[0];
-            this.app.workspace.revealLeaf(leaf);
+            void this.app.workspace.revealLeaf(leaf);
         } else {
             leaf = this.app.workspace.getLeaf('split', 'vertical');
             await leaf.setViewState({
@@ -543,7 +543,7 @@ export class ThemeManagerView extends ItemView {
 
         if (existingLeaves.length > 0) {
             leaf = existingLeaves[0];
-            this.app.workspace.revealLeaf(leaf);
+            void this.app.workspace.revealLeaf(leaf);
         } else {
             leaf = this.app.workspace.getLeaf('split', 'vertical');
             await leaf.setViewState({

--- a/src/themes/builtin/elegant.css
+++ b/src/themes/builtin/elegant.css
@@ -49,7 +49,7 @@
 .mp-content-section p {
   margin: 1em 0;
   line-height: 2;
-  text-indent: 0px;
+  text-indent: 0;
   color: #3f3f3f;
 }
 

--- a/src/themes/custom/wechat-green.css
+++ b/src/themes/custom/wechat-green.css
@@ -55,7 +55,7 @@
 .mp-content-section p {
   margin: 1em 0;
   line-height: 2;
-  text-indent: 0px;
+  text-indent: 0;
   color: #333333;
 }
 

--- a/src/ui/modals.ts
+++ b/src/ui/modals.ts
@@ -1,6 +1,19 @@
 import { App, MarkdownView, Modal, Notice, Setting } from 'obsidian';
 import MPPlugin from '../main';
 import { markdownToHtml } from '../converter';
+
+interface SelectedMaterial {
+	media_id: string;
+	url?: string;
+	name?: string;
+	isLocal?: boolean;
+}
+
+interface SelectedFileInfo {
+	name: string;
+	[path: string]: unknown;
+}
+
 // 封面图选择模态框
 export class CoverImageModal extends Modal {
 	plugin: MPPlugin;
@@ -273,7 +286,7 @@ export class CoverImageModal extends Modal {
 				new Notice('请先选择图片');
 				return;
 			}
-			const material = JSON.parse(selectedMaterial);
+			const material = JSON.parse(selectedMaterial) as SelectedMaterial;
 			this.onImageSelected(material.media_id);
 			this.close();
 		});
@@ -289,7 +302,7 @@ export class CoverImageModal extends Modal {
 					return;
 				}
 
-				const fileInfo = JSON.parse(selectedFileInfo);
+				const fileInfo = JSON.parse(selectedFileInfo) as SelectedFileInfo;
 
 				// 立即上传图片到微信获取 media_id
 				localConfirmButton.disabled = true;
@@ -320,9 +333,9 @@ export class CoverImageModal extends Modal {
 					this.onImageSelected(mediaId);
 					new Notice('封面图上传成功');
 					this.close();
-				} catch (error) {
+				} catch (error: unknown) {
 					console.error('上传封面图失败:', error);
-					new Notice('上传封面图失败：' + (error.message || '未知错误'));
+					new Notice('上传封面图失败：' + (error instanceof Error ? error.message : String(error)));
 					localConfirmButton.disabled = false;
 					localConfirmButton.textContent = '确认';
 				}
@@ -332,13 +345,13 @@ export class CoverImageModal extends Modal {
 		// 分页按钮事件
 		prevButton.addEventListener('click', () => {
 			if (currentPage > 0) {
-				loadMaterialsPage(currentPage - 1);
+				void loadMaterialsPage(currentPage - 1);
 			}
 		});
 
 		nextButton.addEventListener('click', () => {
 			if ((currentPage + 1) * pageSize < totalCount) {
-				loadMaterialsPage(currentPage + 1);
+				void loadMaterialsPage(currentPage + 1);
 			}
 		});
 
@@ -481,7 +494,7 @@ export class PublishModal extends Modal {
 				// 从sessionStorage获取选中的素材信息
 				const selectedMaterial = sessionStorage.getItem('selected_material');
 				if (selectedMaterial) {
-					const material = JSON.parse(selectedMaterial);
+					const material = JSON.parse(selectedMaterial) as SelectedMaterial;
 					if (material.url) {
 						img.src = material.url;
 						this.coverImagePreview.appendChild(img);
@@ -561,7 +574,7 @@ export class PublishModal extends Modal {
 						// 获取选中的封面图 media_id
 						const selectedMaterial = sessionStorage.getItem('selected_material');
 						if (selectedMaterial) {
-							const material = JSON.parse(selectedMaterial);
+							const material = JSON.parse(selectedMaterial) as SelectedMaterial;
 							this.selectedCoverMediaId = material.media_id;
 						}
 
@@ -583,9 +596,9 @@ export class PublishModal extends Modal {
 						if (success) {
 							this.close();
 						}
-					} catch (error) {
+					} catch (error: unknown) {
 						console.error('发布失败:', error);
-						new Notice('发布失败：' + (error.message || '未知错误'));
+						new Notice('发布失败：' + (error instanceof Error ? error.message : String(error)));
 						publishButton.disabled = false;
 						publishButton.textContent = '发布';
 					}

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -27,21 +27,21 @@ export class Logger {
         return this.debugMode;
     }
 
-    public debug(...args: any[]): void {
+    public debug(...args: unknown[]): void {
         if (this.debugMode) {
             console.debug('[DEBUG]', ...args);
         }
     }
 
-    public info(...args: any[]): void {
+    public info(...args: unknown[]): void {
         console.info('[INFO]', ...args);
     }
 
-    public warn(...args: any[]): void {
+    public warn(...args: unknown[]): void {
         console.warn('[WARN]', ...args);
     }
 
-    public error(...args: any[]): void {
+    public error(...args: unknown[]): void {
         console.error('[ERROR]', ...args);
     }
 }

--- a/src/view.ts
+++ b/src/view.ts
@@ -61,7 +61,7 @@ export class MPView extends ItemView {
             attr: { 'aria-label': '刷新预览' },
         });
         setIcon(this.refreshButton, 'refresh-cw');
-        this.refreshButton.addEventListener('click', () => this.forceRefreshPreview());
+        this.refreshButton.addEventListener('click', () => void this.forceRefreshPreview());
 
         // 主题选择器
         const themeOptions = this.getThemeOptions();
@@ -150,7 +150,7 @@ export class MPView extends ItemView {
             const currentSize = parseInt(this.fontSizeSelect.value);
             if (currentSize > 12) {
                 this.fontSizeSelect.value = (currentSize - 1).toString();
-                updateFontSize();
+                void updateFontSize();
             }
         });
 
@@ -158,7 +158,7 @@ export class MPView extends ItemView {
             const currentSize = parseInt(this.fontSizeSelect.value);
             if (currentSize < 30) {
                 this.fontSizeSelect.value = (currentSize + 1).toString();
-                updateFontSize();
+                void updateFontSize();
             }
         });
 
@@ -428,7 +428,7 @@ export class MPView extends ItemView {
         [themeSelect, fontSelect].forEach(select => {
             if (select) {
                 select.classList.toggle('disabled', !enabled);
-                (select as HTMLElement).setCssProps({ 'pointer-events': enabled ? 'auto' : 'none' });
+                (select as HTMLElement).setCssProps({ pointerEvents: enabled ? 'auto' : 'none' });
             }
         });
 
@@ -489,7 +489,7 @@ export class MPView extends ItemView {
             }
 
             this.updateTimer = window.setTimeout(() => {
-                this.updatePreview();
+                void this.updatePreview();
             }, 500);
         }
     }


### PR DESCRIPTION
## 变更内容

### 🔧 代码规范
- 微信 API 响应定义精确接口类型，替代 any 直接访问
- JSON.parse 结果添加类型标注
- catch (error) 改为 unknown，用 instanceof Error 替代直接访问属性
- Logger 方法参数 any[] → unknown[]
- setCssProps 使用 camelCase 属性名
- Promise 调用加 void 前缀
- 移除含禁止 eslint-disable 的辅助函数
- 移除未使用的 parseCssString 导入
- text-indent: 0px → text-indent: 0（兼容性）
- README 补充英文安装说明和使用指南
- ConfirmModal 支持 async onConfirm 回调